### PR TITLE
running the reference implementation one-click in Docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ target/
 /.settings/ 
 /.project 
 /.classpath 
+.factorypath

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM maven:3.5.2-jdk-8-alpine
+WORKDIR /as2-peppol-server
+COPY pom.xml /as2-peppol-server/pom.xml
+COPY src /as2-peppol-server/src
+VOLUME /as2-peppol-server/data
+VOLUME [ "/var/www/peppol-as2/receive", "/var/www/peppol-as2/send" ]
+EXPOSE 8080
+
+RUN apk update
+RUN apk add openssl
+RUN apk add openssh
+
+# generating self signing certificate
+# follow the [instruction](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs)
+# **IMPORTANT** 
+#     * CN -- Common Name must follow PEPPOL AP name convention and be in format : APP_1000000XXX, for example APP_1000000312
+#     * it uses PKCS12 keystore
+#     * AS2 client uses predefined names for the following items:
+#         - aliasname must match to the certificate CN (Common Name)
+#         - key store password shall be 'peppol'
+#         - keystore filename shall be 'test-client-certs.p12' to work with [as2-peppol-client](https://github.com/phax/as2-peppol-client)
+WORKDIR /as2-peppol-server/src/main/resources/keystore
+RUN openssl req \
+    -new \
+    -newkey rsa:2048 \
+    -nodes \
+    -subj "/emailAddress=igor@iwa.fi/CN=APP_1000000312/O=IWA.fi/L=Helsinki/ST=Uusimaa/C=FI" \
+    -keyout my-private.key \
+    -out my-certificate.csr
+RUN openssl x509 -signkey my-private.key -in my-certificate.csr -req -days 365 -out my-certificate.cer
+RUN openssl pkcs12 -export -in my-certificate.cer -inkey my-private.key \
+    -out ap.pilot.p12 -passout pass:peppol -name ap.pilot
+
+# https://www.eclipse.org/jetty/documentation/9.4.x/jetty-maven-plugin.html
+WORKDIR /as2-peppol-server
+RUN mvn package -Dmaven.test.skip=true
+RUN mvn jetty:deploy-war
+CMD ["mvn", "jetty:run"]

--- a/README.md
+++ b/README.md
@@ -26,12 +26,44 @@ Before this project can be run in a useful way a PKCS12 keystore with your PEPPO
 Btw. you need no database to run this server. If you want one just use one - but you don't need to. 
 
 # Run it
-The easiest way to run and debug the application is to execute class `com.helger.peppol.as2server.jetty.RunInJettyPEPPOLAS2` from within your IDE (as a standard Java application). It starts up a minimal server and listens on port 8080. The servlet that receives PEPPOL messages listens to path `/as2/` and supports only HTTP method POST.
-After startup locate your browser to `http://localhost:8080` to check if it is running.
+
+There are two options:
+
+1. **running locally on your machine.** To do so you need to proceed the following steps:
+    * get your machine ready for java development with JDK 1.8.X, maven, some IDE tool, e.g. [Eclipse](https://www.eclipse.org/downloads/)
+    * you generate keystore with your certificate obtained from PEPPOP authority or self-signed (see procedure below)
+    * build the project 
+    * execute class `com.helger.peppol.as2server.jetty.RunInJettyPEPPOLAS2` from within your IDE (as a standard Java application). It starts up a minimal server and listens on port 8080. The servlet that receives PEPPOL messages listens to path `/as2/` and supports only HTTP method POST.
+
+2. **run already prepared application in Docker container** To do so you have [Docker](https://docs.docker.com/get-started/) installed in your machine, then do: `docker build -t refapp . && docker run --rm -p 8080:8080 refapp`. This approach is useful if you need just run the reference implementation against your PEPPOL Access Point implementation.
+
+In either case after the app startup, locate your browser to `http://localhost:8080` to check if it is running.
 
 # Test it
 Now that the AS2 server is running you may have a closer look at my **[as2-peppol-client](https://github.com/phax/as2-peppol-client)** project which lets you send AS2 messages to a server.
 If both client and server are configured correctly a successful message exchange should be easily possible.
+
+## Notes
+
+### Self-signed certificate
+
+* follow the [instruction](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs)
+
+**IMPORTANT** 
+
+    * CN -- Common Name must follow PEPPOL AP name convention and be in format : APP_1000000XXX, for example APP_1000000312
+    * it uses PKCS12 keystore
+    * AS2 client uses predefined names for the following items:
+        - aliasname must match to the certificate CN (Common Name)
+        - key store password shall be 'peppol'
+        - keystore filename shall be 'test-client-certs.p12' to work with [as2-peppol-client](https://github.com/phax/as2-peppol-client)
+
+For example:
+```shell
+    $ openssl req -out teho3-certificate.csr -new -newkey rsa:2048 -nodes -keyout teho3-private.key
+    $ openssl x509 -signkey teho3-private.key -in teho3-certificate.csr -req -days 365 -out teho3.cer
+    $ openssl pkcs12 -export -in teho3.cer -inkey teho3-private.key -out test-client-certs.p12 -passout pass:peppol -name APP_1000000112
+```
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,15 @@
       <artifactId>ph-oton-jetty</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-runner -->
+    <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-runner</artifactId>
+        <version>9.4.12.v20180830</version>
+        <scope>provided</scope>
+    </dependency>
+
   </dependencies>
   
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     <m2e.jaxrs.activation>false</m2e.jaxrs.activation>
     <m2e.jpa.activation>false</m2e.jpa.activation>
     <m2e.jsf.activation>false</m2e.jsf.activation>
+    <jetty.maven.plugin>9.4.3.v20170317</jetty.maven.plugin>
   </properties>
 
   <dependencyManagement>
@@ -244,6 +245,29 @@
             <exclude>jetty-log/**</exclude>
           </excludes>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>${jetty.maven.plugin}</version>
+        <!-- fix for https://stackoverflow.com/questions/26305416/spring-aop-gives-illegalargumentexception-with-java-8 -->
+        <configuration>
+            <webApp>
+                <webInfIncludeJarPattern>.*/^(asm-all-repackaged)[^/]*\.jar$</webInfIncludeJarPattern>
+            </webApp>
+        </configuration>
+        <dependencies>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>5.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-commons</artifactId>
+                <version>5.2</version>
+            </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/src/main/resources/webapp.properties
+++ b/src/main/resources/webapp.properties
@@ -21,7 +21,7 @@ global.debug = true
 global.production = false
 
 # Central directory where the data should be stored
-webapp.datapath = /as2-peppol-server/data
+webapp.datapath = /var/www/peppol-as2/data
 
 # Should all files of the application checked for readability? 
 webapp.checkfileaccess = false

--- a/src/main/resources/webapp.properties
+++ b/src/main/resources/webapp.properties
@@ -21,7 +21,7 @@ global.debug = true
 global.production = false
 
 # Central directory where the data should be stored
-webapp.datapath = /var/www/peppol-as2/data
+webapp.datapath = /as2-peppol-server/data
 
 # Should all files of the application checked for readability? 
 webapp.checkfileaccess = false


### PR DESCRIPTION
Hello Philip

Please review my addition to the project that allows as2-peppol-server running in container. It generates self-signed certificate and setups correct paths for data and keystore. When container is running it can receive PEPPOL documents from third-party PEPPOL implementation. I think it is useful in testing.

Regards,
Igor